### PR TITLE
Added a `.cargo/config.toml` to allow all warnings (there are a ton)

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,0 +1,11 @@
+# `target.*.rustflags` takes precedence over `build.rustflags`, instead of appending,
+# so set it on all targets in case another `.cargo/config.toml` set `target.*.rustflags`.
+# For example, this might be set globally to use a specific faster linker.
+# 
+# See https://github.com/rust-lang/cargo/issues/5376
+# for the issue tracking whether rustflags are appended or overridden.
+[target.'cfg(all())']
+rustflags = ["-A", "warnings"]
+
+[build]
+rustflags = ["-A", "warnings"]


### PR DESCRIPTION
Set `-A warnings` in `RUSTFLAGS` through a `.cargo/config.toml`.  There are a ton of warnings since it's transpiled code, so it creates tons of terminal output every time it's compiled, and since it's just transpiled code, it should be fine to ignore all the warnings at this point.

In `.cargo/config.toml`, I set `rustflags` in two different places, `build.rustflags` and `target.*.rustflags` (where the `*` is done with a `'cfg(all())'` using the vacuously true `all`).  This is necessary because if there is another `.cargo/config.toml`, its `target.*.rustflags` take precedence over our `build.rustflags`.  For example, this might be set globally to use a specific faster linker like `mold` or `lld`.  This behavior of overriding instead of appending `rustflags` might be fixed in cargo (see https://github.com/rust-lang/cargo/issues/5376), but for now it overrides so we should set both `rustflags` fields.