### PR TITLE
Add an `amalgamate.sh` script to create an amalgamated `lighttpd` and transpile it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ cmake_install.cmake
 *.bc
 
 compile_commands.json
+
+amalgamated.compile_commands.json
+lighttpd.amalgamated.*

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,19 @@
 .idea
 *.log
 tmp/
-
+.vscode/
 
 target/
+instrument.target/
+
+build/
+CMakeCache.txt
+CMakeFiles/
+Makefile
+CTestTestfile.cmake
+DartConfiguration.tcl
+cmake_install.cmake
+
+*.bc
+
+compile_commands.json

--- a/amalgamate.mjs
+++ b/amalgamate.mjs
@@ -17,9 +17,13 @@ const commands = JSON.parse((await fsp.readFile("compile_commands.json")).toStri
     ].includes(pathLib.relative("./src", e.file)))
     ;
 
-const includes = commands
-    .map(e => pathLib.relative(".", e.file))
-    .map(path => `#include "${path}"`).join("\n")
+const includes = [
+    // For some reason, this needs to be first in order to define `XXH32`.
+    "src/algo_xxhash.c",
+    ...commands.map(e => pathLib.relative(".", e.file))
+]
+    .map(path => `#include "${path}"`)
+    .join("\n")
     ;
 
 const flags = [...new Set(

--- a/amalgamate.mjs
+++ b/amalgamate.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+import * as fsp from "fs/promises";
+import * as pathLib from "path";
+import * as assert from "assert/strict";
+
+function amalgamatedPath(extension) {
+    return pathLib.resolve(`lighttpd.amalgamated.${extension}`);
+}
+
+const commands = JSON.parse((await fsp.readFile("compile_commands.json")).toString())
+    .filter(e => pathLib.relative(".", e.directory) === "build")
+    .filter(e => ![
+        "lemon.c",
+        // "lighttpd-angel.c",
+    ].includes(pathLib.relative("./src", e.file)))
+    ;
+
+const includes = commands
+    .map(e => pathLib.relative(".", e.file))
+    .map(path => `#include "${path}"`).join("\n")
+    ;
+
+const flags = [...new Set(
+    commands.flatMap(e => (e.arguments ?? e.command.split(/ +/g))
+        .slice(
+            ["cc"].length, 
+            -["-o", "obj", "-c", "src"].length,
+        )
+    )
+)];
+
+const directories = [...new Set(commands.map(e => e.directory))];
+assert.equal(directories.length, 1);
+const directory = directories[0];
+
+const amalgamated = {
+    exe: {
+        directory,
+        arguments: ["cc", ...flags, "-o", amalgamatedPath("exe"), amalgamatedPath("c"), "-lpcre2-8", "-ldl"],
+        file: amalgamatedPath("c"),
+    },
+    ii: {
+        directory,
+        arguments: ["cc", ...flags, "-o", amalgamatedPath("ii"), "-E", amalgamatedPath("c")],
+        file: amalgamatedPath("c"),
+    },
+};
+
+const amalgamatedCommands = [amalgamated.exe];
+
+await fsp.writeFile(amalgamatedPath("c"), includes);
+await fsp.writeFile("amalgamated.compile_commands.json", JSON.stringify(amalgamatedCommands, null, 4));
+
+function toShellCommand(cmd) {
+    const command = cmd.arguments && cmd.arguments.join(" ") || cmd.command;
+    return `(cd "${cmd.directory}" && ${command})`;
+}
+
+console.log(toShellCommand(amalgamated.ii));
+console.log(toShellCommand(amalgamated.exe));

--- a/amalgamate.sh
+++ b/amalgamate.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euox pipefail
+
+cmake -Wno-dev
+make clean
+bear -- make lighttpd
+./amalgamate.mjs | "${SHELL}" -euox pipefail

--- a/amalgamate.sh
+++ b/amalgamate.sh
@@ -2,7 +2,12 @@
 
 set -euox pipefail
 
+rust_dir=lighttpd_rust_amalgamated
+
 cmake -Wno-dev
 make clean
 bear -- make lighttpd
 ./amalgamate.mjs | "${SHELL}" -euox pipefail
+c2rust transpile --overwrite-existing --emit-build-files --binary lighttpd_amalgamated --output-dir ${rust_dir} amalgamated.compile_commands.json
+cp {rust,${rust_dir}}/build.rs
+(cd "${rust_dir}" && cargo build)

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -7,7 +7,11 @@
 #include "sys-time.h"   /* strftime() */
 
 static const char hex_chars_lc[] = "0123456789abcdef";
+
+#ifndef HEX_CHARS_UC
+#define HEX_CHARS_UC
 static const char hex_chars_uc[] = "0123456789ABCDEF";
+#endif
 
 
 __attribute_noinline__

--- a/src/burl.c
+++ b/src/burl.c
@@ -12,7 +12,10 @@
 #include "buffer.h"
 #include "base64.h"
 
+#ifndef HEX_CHARS_UC
+#define HEX_CHARS_UC
 static const char hex_chars_uc[] = "0123456789ABCDEF";
+#endif
 
 /* everything except: ! $ & ' ( ) * + , - . / 0-9 : ; = ? @ A-Z _ a-z ~ */
 static const char encoded_chars_http_uri_reqd[] = {

--- a/src/keyvalue.c
+++ b/src/keyvalue.c
@@ -488,7 +488,10 @@ static void pcre_keyvalue_burl_percent_percent_toupper (buffer *b)
     }
 }
 
+#ifndef HEX_CHARS_UC
+#define HEX_CHARS_UC
 static const char hex_chars_uc[] = "0123456789ABCDEF";
+#endif
 
 static void pcre_keyvalue_burl_percent_high_UTF8 (buffer *b, buffer *t)
 {

--- a/src/mod_magnet.c
+++ b/src/mod_magnet.c
@@ -1020,7 +1020,10 @@ static void magnet_urlenc_query_part(buffer * const b, const char * const s, con
     UNUSED(iskey);
     buffer_append_string_encoded(b, s, slen, ENCODING_REL_URI);
   #else
+    #ifndef HEX_CHARS_UC
+    #define HEX_CHARS_UC
     static const char hex_chars_uc[] = "0123456789ABCDEF";
+    #endif
     char * const p = buffer_string_prepare_append(b, slen*3);
     int j = 0;
     for (size_t i = 0; i < slen; ++i, ++j) {


### PR DESCRIPTION
This adds a script, `amalgamate.sh`, to create an amalgamated `lighttpd` and transpile it.  We want to amalgamate it so that we only have one compilation unit and thus one transpiled Rust module so that we don't have any cross-module imports through `extern`s (vs. the standard `use`).  This way, static analysis will be able to see all function definitions from other modules and we can test static analysis out on much more of `lighttpd`.  This isn't meant as a permanent solution for how static analysis works—eventually, we'll probably want a tool that does the cross-module linking from `extern`s to `use`s and is more careful about everything—but for now, this mostly works amalgamation solution is the simplest for `lighttpd`.

The way this works is it

1. It first generates a `compile_commands.json` specifically for building the `lighttpd` binary.
2. Then for each `file` in that, it creates an amalgamated `lighttpd.amalgamated.c` that `#include`s all of those source `*.c` files.
  i. `lemon.c` is skipped, as this is a separate binary (a parser generator), so it has its own `main` that conflicts.
  ii.  For some reason, if `algo_xxhash.c` is `#include`d where it normally is, it doesn't define `XXH32`, but it does (as normal) when it's `#include`d first.
3. `lighttpd.amalgamated.c` is compiled to `lighttpd.amalgamated.exe`.
  i. `static const char hex_chars_uc[] = "0123456789ABCDEF"` is repeated verbatim in multiple source files, so I added `#ifndef` guards around them all (1a21e8833f722f65cfe48ac1cd0bf58e8f637b0c).
4. An `amalgamated.compile_commands.json` is created that only compiles `lighttpd.amalgamated.c`.  The flags are determined by unioning all of the flags used for all of the files.
5. Finally, `c2rust transpile` is used on `amalgamated.compile_commands.json` to transpile into `lighttpd_rust_amalgamated`.
  i. I didn't include the transpiled Rust in this PR yet.  I'll put it in a subsequent one, and it can be created by running `./amalgamate.sh`.

`./amalgamate.sh` uses `./amalgamate.mjs`, a Node JS script, which uses a modern `node` (tested on `v19.7.0`).  Since this should just be a one-off script to generate the transpiled and amalgamated `lighttpd`, I think it should be fine.