### PR TITLE
Add `-Wl,-export-dynamic` to the amalgamated build to allow it to dynamically load `lighttpd` `mod_*.so`s

### DIFF
--- a/amalgamate.mjs
+++ b/amalgamate.mjs
@@ -42,7 +42,7 @@ const directory = directories[0];
 const amalgamated = {
     exe: {
         directory,
-        arguments: ["cc", ...flags, "-o", amalgamatedPath("exe"), amalgamatedPath("c"), "-lpcre2-8", "-ldl"],
+        arguments: ["cc", ...flags, "-o", amalgamatedPath("exe"), amalgamatedPath("c"), "-lpcre2-8", "-ldl", "-Wl,-export-dynamic"],
         file: amalgamatedPath("c"),
     },
     ii: {

--- a/amalgamate.sh
+++ b/amalgamate.sh
@@ -7,6 +7,7 @@ rust_dir=lighttpd_rust_amalgamated
 cmake -Wno-dev
 make clean
 bear -- make lighttpd
+make mod_{indexfile,dirlisting,staticfile}
 ./amalgamate.mjs | "${SHELL}" -euox pipefail
 c2rust transpile --overwrite-existing --emit-build-files --binary lighttpd_amalgamated --output-dir ${rust_dir} amalgamated.compile_commands.json
 cp {rust,${rust_dir}}/build.rs

--- a/lighttpd_rust_amalgamated/build.rs
+++ b/lighttpd_rust_amalgamated/build.rs
@@ -4,6 +4,7 @@ fn main() {
     // println!("cargo:rustc-flags=-l readline");
     println!("cargo:rustc-link-lib=pcre2-8");
     println!("cargo:rustc-link-lib=crypt");
+    println!("cargo:rustc-link-arg=-Wl,-export-dynamic");
 }
 
 #[cfg(target_os = "macos")]

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -4,6 +4,7 @@ fn main() {
     // println!("cargo:rustc-flags=-l readline");
     println!("cargo:rustc-link-lib=pcre2-8");
     println!("cargo:rustc-link-lib=crypt");
+    println!("cargo:rustc-link-arg=-Wl,-export-dynamic");
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
Add `-Wl,-export-dynamic` to the amalgamated build to allow it to dynamically load `lighttpd` `mod_*.so`s, even C ones.

The previous `rust/` transpile turned the dynamically loaded modules into statically linked Rust modules (I think), so this wasn't an issue before, but since the amalgamated build is for one binary (`lighttpd`), this wasn't done. Perhaps it could be done[^1], too, but for now this works and allows C and Rust to call each other over dynamically loaded FFI.

Link commands aren't saved in `compile_commands.json`, so the link flags are a bit trickier to hunt down and are currently hardcoded.

Since a few modules are needed for running `lighttpd`, `amalgamate.sh` now builds them, but after generating the `compile_commands.json`.

[^1]: Update: It can't be done without source code changes, as all plugins define their own `plugin_data` and `plugin_config` types and these type names clash.