### PR TITLE
Cleanup `lighttpd_rust_amalgamated` into a single `src/main.rs`

### DIFF
--- a/amalgamate.sh
+++ b/amalgamate.sh
@@ -11,7 +11,18 @@ make mod_{indexfile,dirlisting,staticfile}
 ./amalgamate.mjs | "${SHELL}" -euox pipefail
 c2rust transpile --overwrite-existing --emit-build-files --binary lighttpd_amalgamated --output-dir ${rust_dir} amalgamated.compile_commands.json
 cp {rust,${rust_dir}}/build.rs
+mv ${rust_dir} ${rust_dir}.old
+cargo new ${rust_dir}
 (cd "${rust_dir}"
+    cargo add libc
+    cargo add c2rust-bitfields
+    cp ../rust/build.rs .
+    mv ../${rust_dir}.old/rust-toolchain.toml .
+    mv ../${rust_dir}.old/src/lighttpd_amalgamated.rs src/main.rs
+    sed -i 's/#\[macro_use\]//g' src/main.rs
+    sed -i 's/extern crate [^;]*;//g' src/main.rs
+    sed -i 's/use ::lighttpd_rust_amalgamated::\*;/use c2rust_bitfields::BitfieldStruct;/' src/main.rs
     cargo fmt
     cargo build
 )
+rm -rf ${rust_dir}.old

--- a/lighttpd_rust_amalgamated/Cargo.lock
+++ b/lighttpd_rust_amalgamated/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "c2rust-bitfields"
-version = "0.3.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb34f0c0ace43530b2df7f18bc69ee0c4082158aa451ece29602f8c841e73764"
+checksum = "ec83ed829620a77796c348b3c32bc3013f38dc612e1d8b4f4128dbdff85f9ca4"
 dependencies = [
  "c2rust-bitfields-derive",
 ]
 
 [[package]]
 name = "c2rust-bitfields-derive"
-version = "0.2.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dd1601a7b828ab874d890e5a895563ca8ad485bdd3d2a359f148c8b72537241"
+checksum = "a516c617d800450f0941aaafe55bab206c2e8f6fff55fae1f1dfca505fe80a8d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -30,7 +30,7 @@ checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "lighttpd_rust_amalgamated"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "c2rust-bitfields",
  "libc",
@@ -38,9 +38,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
 dependencies = [
  "unicode-ident",
 ]

--- a/lighttpd_rust_amalgamated/Cargo.toml
+++ b/lighttpd_rust_amalgamated/Cargo.toml
@@ -1,12 +1,10 @@
-[workspace]
-members = []
 [package]
 name = "lighttpd_rust_amalgamated"
-authors = ["C2Rust"]
-version = "0.0.0"
-publish = false
+version = "0.1.0"
 edition = "2021"
 
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
 [dependencies]
-c2rust-bitfields = "0.3"
-libc= "0.2"
+c2rust-bitfields = "0.17.0"
+libc = "0.2.140"

--- a/lighttpd_rust_amalgamated/src/main.rs
+++ b/lighttpd_rust_amalgamated/src/main.rs
@@ -8,12 +8,8 @@
     unused_mut
 )]
 #![feature(c_variadic, core_intrinsics, extern_types, label_break_value)]
-#![allow(dead_code)]
 
-use c2rust_bitfields::*;
-extern crate libc;
-extern crate core;
-
+use c2rust_bitfields::BitfieldStruct;
 extern "C" {
     pub type pcre2_real_match_data_8;
     pub type _IO_wide_data;

--- a/run_lighttpd_amalgamated.sh
+++ b/run_lighttpd_amalgamated.sh
@@ -20,6 +20,7 @@ SYSROOT="$(rustc --print sysroot)"
 
 # Find the necessary rlibs
 C2RUST_BITFIELDS=$(find "$MODULE_DIR/target/debug/deps" -name "libc2rust_bitfields*.rlib" -print -quit)
+LIBC=$(find "$MODULE_DIR/target/debug/deps" -name "liblibc*.rlib" -print -quit)
 
 # Print the found rlibs
 echo "Found rlibs:"
@@ -31,4 +32,5 @@ cargo run --bin c2rust-analyze -- "$MODULE_DIR/src/main.rs"\
   --crate-type rlib \
   -L "dependency=$MODULE_DIR/target/debug/deps" \
   -L "$SYSROOT/lib/rustlib/x86_64-unknown-linux-gnu/lib" \
-  --extern c2rust_bitfields="$C2RUST_BITFIELDS"
+  --extern c2rust_bitfields="$C2RUST_BITFIELDS" \
+  --extern libc="$LIBC"


### PR DESCRIPTION
Cleanup `lighttpd_rust_amalgamated` into a single `src/main.rs` with a simple `Cargo.toml` so that it can be run with `c2rust-analyze` easily, just like in #6.  The difference is that these changes are a bit more minimal and modern (e.x. edition 2021), but still work with `c2rust-analyze` if the same `rustc` arguments (as seen from `cargo build --verbose`) are used.